### PR TITLE
Allow queries like "/channels?isFeatured=true"

### DIFF
--- a/v1/api.js
+++ b/v1/api.js
@@ -1,8 +1,9 @@
 var express = require('express');
-var router = express.Router();
+
 var {serializeChannel,
 		 serializeTrack,
 		 serializeImage} = require('./firebase/serializer.js');
+
 var {apiGetImage,
 		 apiGetTrack,
 		 apiGetChannel,
@@ -11,6 +12,8 @@ var {apiGetImage,
 		 apiGetChannelsFiltered,
 		 apiGet,
 		 apiQuery} = require('./firebase/adapter.js');
+
+var router = express.Router();
 
 function notAnEndpoint(req, res) {
   res.status(404).json({ message: 'Impossible to request this endpoint' });
@@ -32,13 +35,16 @@ router.get('/', function (req, res) {
 });
 
 router.get('/channels', function (req, res) {
-  // TODO: remove tracks in reponse (impossible at firebase query)
 	var query = req.query;
+	var promise;
+
 	if (Object.keys(query).length) {
-		apiGetChannelsFiltered(query).then(handleSuccess(res)).catch(handleError(res));
+		promise = apiGetChannelsFiltered(query);
 	} else {
-		apiGetChannels().then(handleSuccess(res)).catch(handleError(res));
+		promise = apiGetChannels();
 	}
+
+	promise.then(handleSuccess(res)).catch(handleError(res));
 });
 
 router.get('/channels/:channelId', function (req, res) {

--- a/v1/firebase/adapter.js
+++ b/v1/firebase/adapter.js
@@ -69,6 +69,11 @@ var FILTERS = {
 
 function apiGetChannelsFiltered(filters) {
   var filterFun = function(filter, val) {
+		// Convert to boolean. Allows queries as `isFeatured=true`.
+		if (val === 'true' || val === 'false') {
+			val = Boolean(val);
+		}
+
     return function(channel) {
       var query = filter.split(".");
 
@@ -82,18 +87,21 @@ function apiGetChannelsFiltered(filters) {
         if (!elem) {
           return false;
         }
+
 				var filterMode = query[1];
 				var filterModeFun = FILTERS[filterMode];
+
 				if (filterModeFun) {
 					return filterModeFun(elem, val);
 				} else {
 					throw Error(`${filterMode} is not a valid filter mode.`);
 				}
-
       }
+
       throw Error(`${filter} is not a valid filter.`);
     }
   }
+
   return apiGetChannels().then(channels =>
     Object.keys(filters).reduce(
       (channels, filter) => channels.filter(filterFun(filter, filters[filter])),


### PR DESCRIPTION
Queries like `isFeatured=true` would be read as a string. This PR dirty-converts `"true"` and `"false"` to booleans which fixes the query.

https://radio4000-api-dcobewnpjx.now.sh/v1/channels?isFeatured=true