### PR TITLE
Add thumbnail

### DIFF
--- a/test.js
+++ b/test.js
@@ -14,3 +14,10 @@ test('there are some channels', async t => {
 	t.is(res.statusCode, 200);
 	t.truthy(res.body.length);
 });
+
+test('channel returns a thumbnail', async t => {
+	var res = await request(app)
+		.get('/v1/channels/-JXHtCxC9Ew-Ilck6iZ8');
+	t.is(res.statusCode, 200);
+	t.truthy(res.body.thumbnail.length);
+});

--- a/test.js
+++ b/test.js
@@ -22,5 +22,5 @@ test('channel returns some data', async t => {
 	t.truthy(res.body.title.length);
 	t.truthy(res.body.tracks.length);
 	t.truthy(res.body.favoriteChannels.length);
-	t.truthy(res.body.thumbnail.length);
+	t.truthy(res.body.image.sizes.small);
 });

--- a/test.js
+++ b/test.js
@@ -15,9 +15,12 @@ test('there are some channels', async t => {
 	t.truthy(res.body.length);
 });
 
-test('channel returns a thumbnail', async t => {
+test('channel returns some data', async t => {
 	var res = await request(app)
 		.get('/v1/channels/-JXHtCxC9Ew-Ilck6iZ8');
 	t.is(res.statusCode, 200);
+	t.truthy(res.body.title.length);
+	t.truthy(res.body.tracks.length);
+	t.truthy(res.body.favoriteChannels.length);
 	t.truthy(res.body.thumbnail.length);
 });

--- a/v1/cloudinary/adapter.js
+++ b/v1/cloudinary/adapter.js
@@ -1,4 +1,4 @@
-var rootUrl = 'https://res.cloudinary.com/radio4000/image/upload/q_50,w_200,h_200,c_thumb,c_fill,fl_lossy/';
+var rootUrl = 'https://res.cloudinary.com/radio4000/image/upload/q_70,w_320,h_320,c_thumb,c_fill,fl_lossy/';
 
 function buildCloudinaryUrl(imageSrc) {
 	return `${rootUrl}${imageSrc}`;

--- a/v1/cloudinary/adapter.js
+++ b/v1/cloudinary/adapter.js
@@ -1,7 +1,15 @@
-var rootUrl = 'https://res.cloudinary.com/radio4000/image/upload/q_70,w_320,h_320,c_thumb,c_fill,fl_lossy/';
+const base = 'https://res.cloudinary.com/radio4000/image/upload';
+const transforms = `q_70,f_auto,fl_lossy`;
+const url = `${base}/${transforms}`;
 
-function buildCloudinaryUrl(imageSrc) {
-	return `${rootUrl}${imageSrc}`;
+function createImageSizes(id) {
+	return {
+		small: `${url},w_200,h_200,c_thumb/${id}`,
+		medium: `${url},w_480,h_480,c_thumb/${id}`,
+		large: `${url},w_1280,h_1280,c_fit/${id}`
+	};
 }
 
-module.exports = {buildCloudinaryUrl};
+module.exports = {
+	createImageSizes
+};

--- a/v1/cloudinary/adapter.js
+++ b/v1/cloudinary/adapter.js
@@ -5,8 +5,7 @@ const url = `${base}/${transforms}`;
 function createImageSizes(id) {
 	return {
 		small: `${url},w_200,h_200,c_thumb/${id}`,
-		medium: `${url},w_480,h_480,c_thumb/${id}`,
-		large: `${url},w_1280,h_1280,c_fit/${id}`
+		medium: `${url},w_640,h_640,c_thumb/${id}`
 	};
 }
 

--- a/v1/firebase/adapter.js
+++ b/v1/firebase/adapter.js
@@ -1,5 +1,5 @@
 var firebase = require('firebase');
-var {serializeChannel, serializeTrack, serializeImage, embedImage} = require('./serializer.js');
+var {serializeChannel, serializeTrack, serializeImage} = require('./serializer.js');
 
 var firebaseConfig = {
 	apiKey: process.env.FIREBASE_API_KEY,
@@ -41,13 +41,9 @@ function apiGetTrack(trackId) {
 function apiGetChannel(channelId) {
 	return apiGet(`channels/${channelId}`).then(snapshot => {
 		var channel = serializeChannel(snapshot.val(), channelId);
-
-		// Get newest image.
-		var images = Object.keys(channel.images);
-		var lastImage = images[images.length - 1];
-		return apiGetImage(lastImage).then(image => {
-			// And embed it on the channel.
-			return embedImage(channel, image);
+		return apiGetImage(channel.image).then(image => {
+			channel.image = image;
+			return channel;
 		});
 	});
 }

--- a/v1/firebase/adapter.js
+++ b/v1/firebase/adapter.js
@@ -40,7 +40,16 @@ function apiGetTrack(trackId) {
 
 function apiGetChannel(channelId) {
 	return apiGet(`channels/${channelId}`).then(snapshot => {
-		return serializeChannel(snapshot.val(), channelId);
+		var channel = serializeChannel(snapshot.val(), channelId);
+
+		// Replace `images` with a single `thumbnail` URL.
+		var images = Object.keys(channel.images)
+		var lastImage = images[images.length - 1]
+		return apiGetImage(lastImage).then(image => {
+			delete channel.images
+			channel.thumbnail = image.src
+			return channel;
+		});
 	});
 }
 

--- a/v1/firebase/adapter.js
+++ b/v1/firebase/adapter.js
@@ -43,11 +43,13 @@ function apiGetChannel(channelId) {
 		var channel = serializeChannel(snapshot.val(), channelId);
 
 		// Replace `images` with a single `thumbnail` URL.
-		var images = Object.keys(channel.images)
-		var lastImage = images[images.length - 1]
+		var images = Object.keys(channel.images);
+		var lastImage = images[images.length - 1];
 		return apiGetImage(lastImage).then(image => {
-			delete channel.images
-			channel.thumbnail = image.src
+			delete channel.images;
+			delete channel.tracks;
+			delete channel.favoriteChannels;
+			channel.thumbnail = image.src;
 			return channel;
 		});
 	});

--- a/v1/firebase/adapter.js
+++ b/v1/firebase/adapter.js
@@ -1,5 +1,5 @@
 var firebase = require('firebase');
-var {serializeChannel, serializeTrack, serializeImage} = require('./serializer.js');
+var {serializeChannel, serializeTrack, serializeImage, embedImage} = require('./serializer.js');
 
 var firebaseConfig = {
 	apiKey: process.env.FIREBASE_API_KEY,
@@ -42,13 +42,12 @@ function apiGetChannel(channelId) {
 	return apiGet(`channels/${channelId}`).then(snapshot => {
 		var channel = serializeChannel(snapshot.val(), channelId);
 
-		// Replace `images` with a single `thumbnail` URL.
+		// Get newest image.
 		var images = Object.keys(channel.images);
 		var lastImage = images[images.length - 1];
 		return apiGetImage(lastImage).then(image => {
-			delete channel.images;
-			channel.thumbnail = image.src;
-			return channel;
+			// And embed it on the channel.
+			return embedImage(channel, image);
 		});
 	});
 }

--- a/v1/firebase/adapter.js
+++ b/v1/firebase/adapter.js
@@ -47,8 +47,6 @@ function apiGetChannel(channelId) {
 		var lastImage = images[images.length - 1];
 		return apiGetImage(lastImage).then(image => {
 			delete channel.images;
-			delete channel.tracks;
-			delete channel.favoriteChannels;
 			channel.thumbnail = image.src;
 			return channel;
 		});

--- a/v1/firebase/serializer.js
+++ b/v1/firebase/serializer.js
@@ -11,13 +11,13 @@ function serializeChannel(channel, channelId) {
 	if (!channel) {
 		return;
 	}
+
+	delete channel.channelPublic;
+
 	channel.id = channelId;
 	channel.tracks = convertHasMany(channel.tracks);
 	channel.favoriteChannels = convertHasMany(channel.favoriteChannels);
-	delete channel.channelPublic;
-	// var images = Object.keys(channel.images || {});
-	// channel.image = buildCloudinaryUrl(images[images.length -1]);
-	// delete channel.images;
+
 	return channel;
 }
 

--- a/v1/firebase/serializer.js
+++ b/v1/firebase/serializer.js
@@ -17,6 +17,11 @@ function serializeChannel(channel, channelId) {
 	channel.id = channelId;
 	channel.tracks = convertHasMany(channel.tracks);
 	channel.favoriteChannels = convertHasMany(channel.favoriteChannels);
+	if (channel.images) {
+		const images = convertHasMany(channel.images);
+		channel.image = images[images.length - 1];
+		delete channel.images;
+	}
 
 	return channel;
 }
@@ -40,16 +45,8 @@ function serializeImage(image, id) {
 	};
 }
 
-// Replace `images` with a single `thumbnail` URL.
-function embedImage(channel, image) {
-	delete channel.images;
-	channel.image = serializeImage(image);
-	return channel;
-}
-
 module.exports = {
 	serializeChannel,
 	serializeTrack,
-	serializeImage,
-	embedImage
+	serializeImage
 };

--- a/v1/firebase/serializer.js
+++ b/v1/firebase/serializer.js
@@ -1,4 +1,4 @@
-var {buildCloudinaryUrl} = require('../cloudinary/adapter.js');
+var {createImageSizes} = require('../cloudinary/adapter.js');
 
 function convertHasMany(fromObject) {
 	if (!fromObject) {
@@ -29,13 +29,27 @@ function serializeTrack(track, trackId) {
 	return track;
 }
 
-function serializeImage(image, imageId) {
+function serializeImage(image, id) {
 	if (!image) {
 		return;
 	}
-	image.src = buildCloudinaryUrl(image.src);
-	image.id = imageId;
-	return image;
+	return {
+		id,
+		src: image.src,
+		sizes: createImageSizes(image.src)
+	};
 }
 
-module.exports = {serializeChannel, serializeTrack, serializeImage};
+// Replace `images` with a single `thumbnail` URL.
+function embedImage(channel, image) {
+	delete channel.images;
+	channel.image = serializeImage(image);
+	return channel;
+}
+
+module.exports = {
+	serializeChannel,
+	serializeTrack,
+	serializeImage,
+	embedImage
+};


### PR DESCRIPTION
Hi, when you fetch a single channel we currently return all its image model ids. But only the newest/latest "exists" on Radio4000.

This PR replaces the `images` object with a single `thumbnail` url from the latest image.