### PR TITLE
Change CDN for player script

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -8,7 +8,7 @@ let apiURL, // URL of this application
 	stripePublicKey
 
 // CDN URL to the radio4000-player script
-const playerScriptURL = 'https://unpkg.com/radio4000-player'
+const playerScriptURL = 'https://cdn.jsdelivr.net/npm/radio4000-player@0/dist/radio4000-player.min.js'
 
 apiURL = 'http://localhost:4001'
 databaseURL = 'https://radio4000-staging.firebaseio.com/'


### PR DESCRIPTION
By using jsdelivr instead of unpkg we get a little bit of statistics. Plus it seems more suited for production usage.

I locked it to the version 0 range we're currently on.