### PR TITLE
feat: allow a track.mediaNotAvailable boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ todo: explain our integration of the Cloudinary service.
 |title|`string`|required title of the track. Example: `"Lydia Lunch - This Side of Nowhere (1982)"`|
 |url|`string`|the URL pointing to the provider serving the track media (YouTube only). Example: `"https://www.youtube.com/watch?v=5R5bETC_wvA"`|
 |ytid|`string`|provider id of a track media (YouTube only). Example: `"5R5bETC_wvA"`|
+|mediaNotAvailable|`boolean`|is the current track media available, accessible to be consumed|
 
 ## Node.js API
 

--- a/database.rules.json
+++ b/database.rules.json
@@ -239,6 +239,9 @@
 					// can only be updated if the value matches the authenticated users channel id
 					".validate": "newData.isString() && root.child('users').child(auth.uid).child('channels').child(newData.val()).exists()"
 				},
+				"mediaNotAvailable": {
+					".validate": "newData.isBoolean()"
+				},
 				"$other": {
 					".validate": false
 				}


### PR DESCRIPTION
In this PR we had the possibility of a `boolean` key on `track.mediaNotAvailable`.

If true, the media is not available for being consumed by the radio4000-player.