### PR TITLE
feat: add the possibility of a discogsUrl onto a track

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ todo: explain our integration of the Cloudinary service.
 |url|`string`|the URL pointing to the provider serving the track media (YouTube only). Example: `"https://www.youtube.com/watch?v=5R5bETC_wvA"`|
 |ytid|`string`|provider id of a track media (YouTube only). Example: `"5R5bETC_wvA"`|
 |mediaNotAvailable|`boolean`|is the current track media available, accessible to be consumed|
+|discogsUrl|`string`|the URL pointing to the Discogs release (or master) corresponding to this track media. Example: `"https://www.discogs.com/Nu-Guinea-Nuova-Napoli/master/1334042"`|
 
 ## Node.js API
 

--- a/database.rules.json
+++ b/database.rules.json
@@ -226,6 +226,9 @@
 				"url": {
 					".validate": "newData.isString() && newData.val().length > 3"
 				},
+				"discogsUrl": {
+					".validate": "newData.isString() && newData.val().length > 3"
+				},
 				"title": {
 					".validate": "newData.isString() && newData.val().length > 0"
 				},


### PR DESCRIPTION
This PR adds the possibility to store a string under `track.discogsUrl`.

This is supposed to help users link a media to its context.

The end usage will be that users on r4 will get meta data saved on their tracks library https://github.com/internet4000/radio4000/pull/251

Open questions:

+ Where do we store the track data? `track.label`? `track.labelName`?
+ Which data do we store exactly? Label, year, genre/styles, artist etc.

If we store this new data under properties, such as `track.releaseYear`, then we need to explicitly allow these new `track` model keys on the API. It does not seem like a good idea to let the track model open to any key the user would like to add.

Data about a release can be found here: https://edapi.glitch.me/releases/6980600

Track infos we would like to store on the track object:
- `styles`: a string will all styles?  `House Vaporwave IDM`. So we can search by track.stryle.contains?
- `labels/label`: singular or plural? a string or an array? Array in firebase are annoying. A release can have multiple labels, but I guess the user is interested in only one. Maybe in two or more for advanced users?
- `year`: example `2013`, a number for the release year
- `genres`, same questions as styles. Should they be merged?
- `country`, example: `Germany`, a country in which the artist released the track/release. Maybe this can also be made a #hashtag?

I'm thinking that in the end we're happy already as users when the track we like can be linked to a discogs url; so then it is easy to remember releases we like the track of.

Then, since that we have the ID from the url, we can query some data to discogs (the one we're discussing above), and store it directly on the track. The good thing about this, is that without any network request (to discogs), we can already have loaded in r4 some additionnal data such as the label and release year, to organize our tracks, explore the tracks from other radio channels in a new neat way.

Therefore, in one radio4000 channel, all tracks can have a discogs id that can be reused later, and in the meantime we directly store some of this discogs info onto the track.
Since our use case is search and filtering on tracks, i'm wondering if some of the data can be merged into less properties.

For example instead of having each of this discogs releases properties on the track as similarly named properties, we could also store of of them as word in a string.
`2013 200ok electronic house vaporwave germany`
Maybe all lower cases and separated with `-` for multiple words.
Therefore we can display this information as `#2013 #200ok #electronic #house #vaporwave #germany`.

One problem I see with this approach is if a label name is for example `2013`, confusion between a release year and a label name. And since we're not storing tag types, it will be impossible to differentiate both.

