### PR TITLE
fix track.discogsUrl length

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -230,7 +230,7 @@
 					".validate": "newData.isString() && newData.val().length > 3"
 				},
 				"discogsUrl": {
-					".validate": "newData.isString() && newData.val().length > 3 && newData.val().length < 150|| newData.val().length === 0"
+					".validate": "newData.isString() && newData.val().length > 3 && newData.val().length < 300 || newData.val().length === 0"
 				},
 				"title": {
 					".validate": "newData.isString() && newData.val().length > 0"


### PR DESCRIPTION
https://www.discogs.com/%D0%98%D0%BD%D1%82%D1%83%D1%80%D0%B8%D1%81%D1%82-%D0%9A%D0%BE%D0%BC%D0%B0%D0%BD%D0%B4%D0%B8%D1%80%D0%BE%D0%B2%D0%BA%D0%B0/release/12572791

is how this url 

https://www.discogs.com/%D0%98%D0%BD%D1%82%D1%83%D1%80%D0%B8%D1%81%D1%82-%D0%9A%D0%BE%D0%BC%D0%B0%D0%BD%D0%B4%D0%B8%D1%80%D0%BE%D0%B2%D0%BA%D0%B0/release/12572791

is "translated" when added to r4

so, longer than 150 chars — which is why i made it 300