### PR TITLE
fix travis deploy steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,8 @@ jobs:
     - stage: test
       script: yarn test
 
-    - stage: deploy-staging
-      if: branch IN (master)
-      script:
-        - yarn deploy-rules
-        - yarn deploy-api
-
-    - stage: deploy-production
-      if: branch = production
-      script:
-        - yarn deploy-rules-production
-        - yarn deploy-api-production
+deploy:
+  provider: script
+  script: bash scripts/deploy.sh production
+  on:
+    branch: production

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ $1 == "production" ]
+then
+  yarn deploy-rules-production
+  yarn deploy-api-production
+else
+	yarn deploy-rules
+  yarn deploy-api
+fi


### PR DESCRIPTION
previously, travis was deploying each time it was testing.

now it should deploy only when merged; https://docs.travis-ci.com/user/deployment/script/

> Note: could also have used `after_success` https://docs.travis-ci.com/user/job-lifecycle/